### PR TITLE
[Follow-up] リファクタリング: 起動処理の堅牢性を改善

### DIFF
--- a/ping-after-wifi.env
+++ b/ping-after-wifi.env
@@ -1,0 +1,7 @@
+# ping-after-wifi settings
+# Copy to /etc/default/ping-after-wifi and edit as needed.
+
+NETWORK_INTERFACE=wlan0
+PING_TARGET=192.168.10.3
+PING_COUNT=4
+MAX_WAIT_SECONDS=60

--- a/ping-after-wifi.service
+++ b/ping-after-wifi.service
@@ -1,12 +1,15 @@
 [Unit]
-Description=Ping target after Wifi is connected
+Description=Ping target after network is connected
 After=NetworkManager.service
 Wants=NetworkManager.service
 
 [Service]
 Type=oneshot
-Environment=INTERFACE=wlan0
+EnvironmentFile=-/etc/default/ping-after-wifi
+Environment=NETWORK_INTERFACE=wlan0
+Environment=PING_TARGET=192.168.10.3
 Environment=PING_COUNT=4
+Environment=MAX_WAIT_SECONDS=60
 ExecStart=/usr/local/bin/ping_target.sh
 
 [Install]

--- a/ping_target.sh
+++ b/ping_target.sh
@@ -1,17 +1,67 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
-INTERFACE="wlan0"
-TARGET="192.168.10.3"
+readonly DEFAULT_NETWORK_INTERFACE="wlan0"
+readonly DEFAULT_PING_TARGET="192.168.10.3"
+readonly DEFAULT_PING_COUNT="4"
+readonly DEFAULT_MAX_WAIT_SECONDS="60"
+readonly POLL_INTERVAL_SECONDS="2"
 
-echo "Waiting for $INTERFACE IP..."
+NETWORK_INTERFACE="${NETWORK_INTERFACE:-${INTERFACE:-$DEFAULT_NETWORK_INTERFACE}}"
+PING_TARGET="${PING_TARGET:-${TARGET:-$DEFAULT_PING_TARGET}}"
+PING_COUNT="${PING_COUNT:-$DEFAULT_PING_COUNT}"
+MAX_WAIT_SECONDS="${MAX_WAIT_SECONDS:-$DEFAULT_MAX_WAIT_SECONDS}"
 
-until ip addr show "$INTERFACE" | grep -q "inet "; do
-    sleep 2
-done
+log() {
+    echo "[ping-after-wifi] $*"
+}
 
-echo "$INTERFACE ready"
+require_command() {
+    local command_name="$1"
+    if ! command -v "$command_name" >/dev/null 2>&1; then
+        log "ERROR: command '$command_name' is not available"
+        exit 1
+    fi
+}
 
-ping -c 4 "$TARGET"
+validate_interface() {
+    if ! nmcli -g DEVICE device status | grep -Fxq "$NETWORK_INTERFACE"; then
+        log "ERROR: network interface '$NETWORK_INTERFACE' is not managed by NetworkManager"
+        exit 1
+    fi
+}
 
-echo "Done"
-exit 0
+wait_for_connected() {
+    local elapsed_seconds=0
+
+    log "Waiting up to ${MAX_WAIT_SECONDS}s for '$NETWORK_INTERFACE' to become connected"
+
+    while (( elapsed_seconds < MAX_WAIT_SECONDS )); do
+        if [[ "$(nmcli -t -f GENERAL.STATE device show "$NETWORK_INTERFACE" 2>/dev/null || true)" == "GENERAL.STATE:100 (connected)" ]]; then
+            log "Interface '$NETWORK_INTERFACE' is connected"
+            return 0
+        fi
+
+        sleep "$POLL_INTERVAL_SECONDS"
+        ((elapsed_seconds += POLL_INTERVAL_SECONDS))
+    done
+
+    log "ERROR: timeout waiting for '$NETWORK_INTERFACE' to connect"
+    return 1
+}
+
+run_ping() {
+    log "Pinging '$PING_TARGET' with count=$PING_COUNT"
+    ping -c "$PING_COUNT" "$PING_TARGET"
+}
+
+main() {
+    require_command nmcli
+    require_command ping
+    validate_interface
+    wait_for_connected
+    run_ping
+    log "Completed"
+}
+
+main "$@"


### PR DESCRIPTION
### Motivation
- 起動時にネットワーク接続完了を待って `ping` を実行する処理の堅牢性と可読性を向上させるため。 

### Description
- `ping_target.sh` を関数化して `set -euo pipefail` を導入し、入力検証とエラー検出を強化した。 
- `nmcli` / `ping` の存在チェックおよび対象インターフェースが NetworkManager 管理下にあるかの検証を追加した。 
- `nmcli` の `GENERAL.STATE` をポーリングして接続を待機する `wait_for_connected` を実装し、タイムアウト制御（`MAX_WAIT_SECONDS`）を導入した。 
- 環境変数を標準化して後方互換（`INTERFACE`/`TARGET`）も維持し、`ping-after-wifi.service` に `EnvironmentFile=-/etc/default/ping-after-wifi` を追加し、設定サンプル `ping-after-wifi.env` を追加した。 

### Testing
- `bash -n ping_target.sh` による構文チェックを実行し成功した。 
- モック `nmcli`/`ping` を用いて `PATH` に置いた状態で `NETWORK_INTERFACE=wlan0 PING_TARGET=example.com PING_COUNT=2 MAX_WAIT_SECONDS=4 ./ping_target.sh` を実行し、接続待機→ping 実行のフローが期待どおり動作することを確認（成功）。 
- `systemd-analyze verify ping-after-wifi.service` はローカルで `ExecStart` のスクリプトが `/usr/local/bin` に存在しないため警告（期待どおりの検出、配置後は解消）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bc632778083218e6ea8fb6f0f7a70)